### PR TITLE
dont show as link if no url/href

### DIFF
--- a/src/node-results/table.js
+++ b/src/node-results/table.js
@@ -21,10 +21,12 @@ export class NodeTable extends Component {
         );
         return {
           firstCol: field,
-          secondCol: (
+          secondCol: linkUrl ? (
             <a className='nowrap' href={linkUrl}>
               {linkText}
             </a>
+          ) : (
+            linkText
           )
         };
       } else {


### PR DESCRIPTION
Some nodes may have a `source` field but not a `url` field, as @cgreene  discovered with Pathways sourced from Reactome:

![image](https://user-images.githubusercontent.com/8326331/73668814-6998e580-4674-11ea-9b26-316799ec4034.png)

This PR makes it such that if there is no `url`, it doesn't show as a link, and doesn't mislead the user into thinking the link will take them somewhere.